### PR TITLE
[memory] Temporary fix for memory

### DIFF
--- a/include/memory/memory.hpp
+++ b/include/memory/memory.hpp
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <limits>
+#include <vector>
 
 #include "support.hpp"
 
@@ -13,9 +14,10 @@ namespace sim {
  */
 class Memory final {
   static constexpr uint32_t MEM_SIZE = std::numeric_limits<paddress_t>::max();
-  std::array<byte_t, MEM_SIZE> m_mem;
+  std::vector<byte_t> m_mem;
 
 public:
+  Memory() { m_mem.resize(MEM_SIZE); }
   /// @brief Write \p nbytes bytes from \p src to \p addr in physical memory
   void writeRaw(paddress_t addr, const byte_t *src, size_t nbytes);
   /// @brief Read \p nbytes bytes from physical address \p addr to dst pointer
@@ -23,12 +25,11 @@ public:
 
   /// @brief
   /// @param addr
-  word_t  readWord (paddress_t addr) const;
+  word_t readWord(paddress_t addr) const;
   hword_t readHWord(paddress_t addr) const;
   bword_t readBWord(paddress_t addr) const;
 
-
-  void writeWord (paddress_t addr, word_t value);
+  void writeWord(paddress_t addr, word_t value);
   void writeHWord(paddress_t addr, hword_t value);
   void writeBWord(paddress_t addr, bword_t value);
 


### PR DESCRIPTION
Fixed stack overflow error, caused by static allocation of std::array in memory class. Now allocating in heap via std::vector. Has to be replaced by a proper MMU.